### PR TITLE
One problem solved

### DIFF
--- a/app_hu.arb
+++ b/app_hu.arb
@@ -174,7 +174,7 @@
     "s_ci_icon_g7": "Pride",
     "s_ci_icon_g8": "Pride ",
     "s_c_theme_header": "Téma",
-    "s_c_theme_auto":  "Autómatikus",
+    "s_c_theme_auto":  "Automatikus",
     "s_c_theme_light":  "Világos",
     "s_c_theme_dark":  "Sötét",
 


### PR DESCRIPTION
- Az Autómatikus - Automatikusra javítva...

https://wiki.startlap.hu/hogyan-irjuk-helyesen-automatikus-vagy-automatikus/